### PR TITLE
Add `BP_POETRY_RUN_TARGET` to configure the poetry run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ pack build <app-name> -p <path-to-app> \
 ### Configuration
 
 #### Custom run command
-This buildpack will set a start command that begins with `poetry run`. You can configure a custom command by using `BP_POETRY_RUN_TARGET`.
-
-- Example: If `BP_POETRY_RUN_TARGET=default_app.server:run`, this buildpack will set a start command of `poetry run default_app.server:run`.
-- Example: If `BP_POETRY_RUN_TARGET=python`, this buildpack will set a start command of `poetry run python`, which will effectively launch the Python REPL.
+This buildpack will set a start command that begins with `poetry run`.
+This can be set using `BP_POETRY_RUN_TARGET` and can reference either a script key from `pyproject.toml` or an executable on the file system.
+See the [`poetry run` documentation](https://python-poetry.org/docs/cli/#run) for more information.
 
 #### Enabling reloadable process types
 You can configure this buildpack to wrap the entrypoint process of your app such that it kills and restarts the process whenever files change in the app's working directory in the container. With this feature enabled, copying new versions of source code into the running container will trigger your app's process to restart. Set the environment variable `BP_LIVE_RELOAD_ENABLED=true` at build time to enable this feature.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Poetry Run Cloud Native Buildpack
 ## `gcr.io/paketo-buildpacks/poetry-run`
 
-The Paketo Poetry Run CNB sets the start command for a given
-[poetry](https://python-poetry.org/) application. The buildpack expects that
-the app contains a valid `pyproject.toml` at the root, and that it has **exactly one poetry script**.
+The Paketo Poetry Run CNB sets the start command for a given [poetry](https://python-poetry.org/) application.
 
-More specifically, the buildpack requires that `pyproject.toml` looks like the following:
+This buildpack detects when one of the following conditions is met:
+
+1. ### `BP_POETRY_RUN_TARGET` is set
+Example: `BP_POETRY_RUN_TARGET=default_app.server:run`.
+The resulting start command for this example would be `poetry run default_app.server:run`.
+
+1. ### `pyproject.toml` exists and contains **exactly one** poetry script
+More specifically, the buildpack will detect if `pyproject.toml` looks like the following:
 
 ```
 [tool.poetry.scripts]
@@ -35,16 +40,11 @@ can use to build your app as follows:
 pack build <app-name> -p <path-to-app> -b <path/to/cpython.cnb> -b <path/to/pip.cnb> -b <path/to/poetry.cnb> -b <path/to/poetry-install.cnb> -b build/buildpackage.cnb
 ```
 
-## Application Detection
-This buildpack detects on the presence of **exactly one** poetry script defined in `pyproject.toml`.
-More specifically, the buildpack will detect if `pyproject.toml` looks like the following:
-
-```
-[tool.poetry.scripts]
-some-script = "some.module:some_method"
-```
-
 ### Configuration
+
+#### Custom run command
+This buildpack will set a start command that begins with `poetry run`. You can configure a custom command by using `BP_POETRY_RUN_TARGET`.
+Example: If `BP_POETRY_RUN_TARGET=default_app.server:run`, this buildpack will set a start command of `poetry run default_app.server:run`.
 
 #### Enabling reloadable process types
 You can configure this buildpack to wrap the entrypoint process of your app such that it kills and restarts the process whenever files change in the app's working directory in the container. With this feature enabled, copying new versions of source code into the running container will trigger your app's process to restart. Set the environment variable `BP_LIVE_RELOAD_ENABLED=true` at build time to enable this feature.
@@ -63,6 +63,5 @@ To run all integration tests, run:
 
 ## Known issues and limitations
 
-* Only one (and exactly one) script may be defined in the `pyproject.toml`
-  file. Zero scripts, or multiple scripts, will result in the buildpack failing
-  detection and therefore not participating in the order group.
+* When `BP_POETRY_RUN_TARGET` is not set, only one (and exactly one) script may be defined in the `pyproject.toml` file.
+  Zero scripts, or multiple scripts, will result in the buildpack failing detection and therefore not participating in the order group.

--- a/README.md
+++ b/README.md
@@ -37,14 +37,21 @@ $ ./scripts/package.sh --version <version-number>
 This will create a `buildpackage.cnb` file under the `build` directory which you
 can use to build your app as follows:
 ```
-pack build <app-name> -p <path-to-app> -b <path/to/cpython.cnb> -b <path/to/pip.cnb> -b <path/to/poetry.cnb> -b <path/to/poetry-install.cnb> -b build/buildpackage.cnb
+pack build <app-name> -p <path-to-app> \
+  -b <path/to/cpython.cnb> \
+  -b <path/to/pip.cnb> \
+  -b <path/to/poetry.cnb> \
+  -b <path/to/poetry-install.cnb> \
+  -b build/buildpackage.cnb
 ```
 
 ### Configuration
 
 #### Custom run command
 This buildpack will set a start command that begins with `poetry run`. You can configure a custom command by using `BP_POETRY_RUN_TARGET`.
-Example: If `BP_POETRY_RUN_TARGET=default_app.server:run`, this buildpack will set a start command of `poetry run default_app.server:run`.
+
+- Example: If `BP_POETRY_RUN_TARGET=default_app.server:run`, this buildpack will set a start command of `poetry run default_app.server:run`.
+- Example: If `BP_POETRY_RUN_TARGET=python`, this buildpack will set a start command of `poetry run python`, which will effectively launch the Python REPL.
 
 #### Enabling reloadable process types
 You can configure this buildpack to wrap the entrypoint process of your app such that it kills and restarts the process whenever files change in the app's working directory in the container. With this feature enabled, copying new versions of source code into the running container will trigger your app's process to restart. Set the environment variable `BP_LIVE_RELOAD_ENABLED=true` at build time to enable this feature.

--- a/build.go
+++ b/build.go
@@ -2,6 +2,7 @@ package poetryrun
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -11,19 +12,29 @@ import (
 // Build will return a packit.BuildFunc that will be invoked during the build
 // phase of the buildpack lifecycle.
 //
-// Build assigns the image a launch process of 'poetry run <script>' where <script>
-// is the key of the only script present for Poetry to run.
+// Build assigns the image a launch process of 'poetry run <target>' where <target>
+// is the key of a poetry script or system executable. This can be set via `BP_POETRY_RUN_TARGET`
+// or inferred from pyproject.toml when there is exactly one script.
 func Build(pyProjectParser PyProjectParser, logger scribe.Emitter) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
-		scriptKey, err := pyProjectParser.Parse(filepath.Join(context.WorkingDir, "pyproject.toml"))
-		if err != nil {
-			return packit.BuildResult{}, err
+		var command string
+
+		logger.Debug.Process("Finding the poetry run target")
+		if runTarget, ok := os.LookupEnv("BP_POETRY_RUN_TARGET"); ok {
+			command = fmt.Sprintf("poetry run %s", runTarget)
+			logger.Debug.Subprocess("Found BP_POETRY_RUN_TARGET=%s", runTarget)
+		} else {
+			scriptKey, err := pyProjectParser.Parse(filepath.Join(context.WorkingDir, "pyproject.toml"))
+			if err != nil {
+				return packit.BuildResult{}, err
+			}
+			command = fmt.Sprintf("poetry run %s", scriptKey)
+			logger.Debug.Subprocess("Found pyproject.toml script=%s", scriptKey)
 		}
 
 		logger.Process("Assigning launch process")
-		command := fmt.Sprintf("poetry run %s", scriptKey)
 		logger.Subprocess("web: %s", command)
 
 		return packit.BuildResult{

--- a/build_test.go
+++ b/build_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
 func testBuild(t *testing.T, context spec.G, it spec.S) {
@@ -26,7 +27,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		pyProjectParser *fakes.PyProjectParser
 
-		build packit.BuildFunc
+		build        packit.BuildFunc
+		buildContext packit.BuildContext
 	)
 
 	it.Before(func() {
@@ -41,22 +43,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 
 		buffer = bytes.NewBuffer(nil)
-		logger := scribe.NewEmitter(buffer)
+		logger := scribe.NewEmitter(buffer).WithLevel("DEBUG")
 
 		pyProjectParser = &fakes.PyProjectParser{}
 		pyProjectParser.ParseCall.Returns.String = "some-script"
 
 		build = poetryrun.Build(pyProjectParser, logger)
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(layersDir)).To(Succeed())
-		Expect(os.RemoveAll(cnbDir)).To(Succeed())
-		Expect(os.RemoveAll(workingDir)).To(Succeed())
-	})
-
-	it("returns a result that sets the 'poetry run' launch command", func() {
-		result, err := build(packit.BuildContext{
+		buildContext = packit.BuildContext{
 			WorkingDir: workingDir,
 			CNBPath:    cnbDir,
 			Stack:      "some-stack",
@@ -68,49 +61,112 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Entries: []packit.BuildpackPlanEntry{},
 			},
 			Layers: packit.Layers{Path: layersDir},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		}
+	})
 
-		Expect(result).To(Equal(packit.BuildResult{
-			Plan: packit.BuildpackPlan{
-				Entries: nil,
-			},
-			Layers: nil,
-			Launch: packit.LaunchMetadata{
-				Processes: []packit.Process{
-					{
-						Type:    "web",
-						Command: "poetry run some-script",
-						Default: true,
+	it.After(func() {
+		Expect(os.RemoveAll(layersDir)).To(Succeed())
+		Expect(os.RemoveAll(cnbDir)).To(Succeed())
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
+	context("with BP_POETRY_RUN_TARGET not set", func() {
+		it("returns a result that sets the 'poetry run' launch command", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(packit.BuildResult{
+				Plan: packit.BuildpackPlan{
+					Entries: nil,
+				},
+				Layers: nil,
+				Launch: packit.LaunchMetadata{
+					Processes: []packit.Process{
+						{
+							Type:    "web",
+							Command: "poetry run some-script",
+							Default: true,
+						},
 					},
 				},
-			},
-		}))
+			}))
+
+			Expect(buffer.String()).To(ContainLines(
+				ContainSubstring("Finding the poetry run target"),
+				ContainSubstring("Found pyproject.toml script=some-script"),
+				ContainSubstring("Assigning launch process"),
+				ContainSubstring("web: poetry run some-script"),
+			))
+		})
+	})
+
+	context("with BP_POETRY_RUN_TARGET set", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_POETRY_RUN_TARGET", "a custom command")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_POETRY_RUN_TARGET")).To(Succeed())
+		})
+
+		it("will use the value of BP_POETRY_RUN_TARGET and not use the pyproject.toml parser", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(packit.BuildResult{
+				Plan: packit.BuildpackPlan{
+					Entries: nil,
+				},
+				Layers: nil,
+				Launch: packit.LaunchMetadata{
+					Processes: []packit.Process{
+						{
+							Type:    "web",
+							Command: "poetry run a custom command",
+							Default: true,
+						},
+					},
+				},
+			}))
+
+			Expect(buffer.String()).To(ContainLines(
+				ContainSubstring("Finding the poetry run target"),
+				ContainSubstring("Found BP_POETRY_RUN_TARGET=a custom command"),
+				ContainSubstring("Assigning launch process"),
+				ContainSubstring("web: poetry run a custom command"),
+			))
+			Expect(pyProjectParser.ParseCall.CallCount).To(Equal(0))
+		})
 	})
 
 	context("failure cases", func() {
-		context("when the pyproject.toml parser returns an error", func() {
+		context("when BP_POETRY_RUN_TARGET is not set", func() {
 			it.Before(func() {
-				pyProjectParser.ParseCall.Returns.Error = fmt.Errorf("some error")
+				Expect(os.Unsetenv("BP_POETRY_RUN_TARGET")).To(Succeed())
 			})
 
-			it("returns the error", func() {
-				_, err := build(packit.BuildContext{
-					WorkingDir: workingDir,
-					CNBPath:    cnbDir,
-					Stack:      "some-stack",
-					BuildpackInfo: packit.BuildpackInfo{
-						Name:    "Some Buildpack",
-						Version: "some-version",
-					},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{},
-					},
-					Layers: packit.Layers{Path: layersDir},
+			context(" and the pyproject.toml parser returns an error", func() {
+				it.Before(func() {
+					pyProjectParser.ParseCall.Returns.Error = fmt.Errorf("some error")
 				})
-				Expect(err).To(MatchError(ContainSubstring("some error")))
+
+				it("returns the error", func() {
+					_, err := build(packit.BuildContext{
+						WorkingDir: workingDir,
+						CNBPath:    cnbDir,
+						Stack:      "some-stack",
+						BuildpackInfo: packit.BuildpackInfo{
+							Name:    "Some Buildpack",
+							Version: "some-version",
+						},
+						Plan: packit.BuildpackPlan{
+							Entries: []packit.BuildpackPlanEntry{},
+						},
+						Layers: packit.Layers{Path: layersDir},
+					})
+					Expect(err).To(MatchError(ContainSubstring("some error")))
+				})
 			})
 		})
 	})
-
 }

--- a/detect.go
+++ b/detect.go
@@ -31,13 +31,10 @@ type PyProjectParser interface {
 // defined in the pyproject.toml under [tool.poetry.scripts]
 func Detect(pyProjectParser PyProjectParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		script, err := pyProjectParser.Parse(filepath.Join(context.WorkingDir, "pyproject.toml"))
-		if err != nil {
+		if script, err := pyProjectParser.Parse(filepath.Join(context.WorkingDir, "pyproject.toml")); err != nil {
 			return packit.DetectResult{}, err
-		}
-
-		if script == "" {
-			return packit.DetectResult{}, packit.Fail
+		} else if script == "" {
+			return packit.DetectResult{}, packit.Fail.WithMessage("Expects one and exactly one script defined in pyproject.toml")
 		}
 
 		requirements := []packit.BuildPlanRequirement{
@@ -74,7 +71,6 @@ func Detect(pyProjectParser PyProjectParser) packit.DetectFunc {
 
 		return packit.DetectResult{
 			Plan: packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{},
 				Requires: requirements,
 			},
 		}, nil

--- a/detect_test.go
+++ b/detect_test.go
@@ -24,16 +24,121 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		pyProjectParser = &fakes.PyProjectParser{}
-		pyProjectParser.ParseCall.Returns.String = "some-script"
 
 		detect = poetryrun.Detect(pyProjectParser)
 	})
 
-	context("detection", func() {
-		it("returns a build plan", func() {
-			result, err := detect(packit.DetectContext{
-				WorkingDir: "a-working-dir",
+	context("with BP_POETRY_RUN_TARGET not set", func() {
+		it.Before(func() {
+			Expect(os.Unsetenv("BP_POETRY_RUN_TARGET")).To(Succeed())
+		})
+
+		context("when pyproject.toml parser returns a valid script", func() {
+			it.Before(func() {
+				pyProjectParser.ParseCall.Returns.String = "some-script"
 			})
+
+			it("returns a build plan", func() {
+				result, err := detect(packit.DetectContext{
+					WorkingDir: "a-working-dir",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result.Plan).To(Equal(packit.BuildPlan{
+					Requires: []packit.BuildPlanRequirement{
+						{
+							Name: poetryrun.CPython,
+							Metadata: poetryrun.BuildPlanMetadata{
+								Launch: true,
+							},
+						},
+						{
+							Name: poetryrun.Poetry,
+							Metadata: poetryrun.BuildPlanMetadata{
+								Launch: true,
+							},
+						},
+						{
+							Name: poetryrun.PoetryVenv,
+							Metadata: poetryrun.BuildPlanMetadata{
+								Launch: true,
+							},
+						},
+					},
+				}))
+
+				Expect(pyProjectParser.ParseCall.Receives.String).To(Equal(filepath.Join("a-working-dir", "pyproject.toml")))
+			})
+
+			context("when BP_LIVE_RELOAD_ENABLED=true", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "true")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+				})
+
+				it("requires watchexec at launch", func() {
+					result, err := detect(packit.DetectContext{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: poetryrun.CPython,
+								Metadata: poetryrun.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+							{
+								Name: poetryrun.Poetry,
+								Metadata: poetryrun.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+							{
+								Name: poetryrun.PoetryVenv,
+								Metadata: poetryrun.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+							{
+								Name: poetryrun.Watchexec,
+								Metadata: poetryrun.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+						},
+					}))
+				})
+			})
+		})
+
+		context("when the pyproject.toml parser cannot find a script", func() {
+			it.Before(func() {
+				pyProjectParser.ParseCall.Returns.String = ""
+			})
+
+			it("fails detection", func() {
+				_, err := detect(packit.DetectContext{})
+
+				Expect(err).To(MatchError(packit.Fail.WithMessage("Expects one and exactly one script defined in pyproject.toml")))
+			})
+		})
+	})
+
+	context("with BP_POETRY_RUN_TARGET set", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_POETRY_RUN_TARGET", "a custom command")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_POETRY_RUN_TARGET")).To(Succeed())
+		})
+
+		it("returns a build plan", func() {
+			result, err := detect(packit.DetectContext{})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
@@ -59,7 +164,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				},
 			}))
 
-			Expect(pyProjectParser.ParseCall.Receives.String).To(Equal(filepath.Join("a-working-dir", "pyproject.toml")))
+			Expect(pyProjectParser.ParseCall.CallCount).To(Equal(0))
 		})
 
 		context("when BP_LIVE_RELOAD_ENABLED=true", func() {
@@ -105,20 +210,14 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				}))
 			})
 		})
+	})
 
-		context("when there is no script returned by the parser", func() {
+	context("failure cases", func() {
+		context("when BP_POETRY_RUN_TARGET is not set", func() {
 			it.Before(func() {
-				pyProjectParser.ParseCall.Returns.String = ""
+				Expect(os.Unsetenv("BP_POETRY_RUN_TARGET")).To(Succeed())
 			})
 
-			it("fails detection", func() {
-				_, err := detect(packit.DetectContext{})
-
-				Expect(err).To(MatchError(packit.Fail.WithMessage("Expects one and exactly one script defined in pyproject.toml")))
-			})
-		})
-
-		context("failure cases", func() {
 			context("when the pyproject.toml parser returns an error", func() {
 				it.Before(func() {
 					pyProjectParser.ParseCall.Returns.Error = fmt.Errorf("some error")
@@ -129,14 +228,20 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Expect(err).To(MatchError(ContainSubstring("some error")))
 				})
 			})
+		})
 
-			context("when BP_LIVE_RELOAD_ENABLED is set to an invalid value", func() {
+		context("when BP_LIVE_RELOAD_ENABLED is set to an invalid value", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "not-a-bool")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+			})
+
+			context("when pyproject.toml parser returns a valid script", func() {
 				it.Before(func() {
-					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "not-a-bool")).To(Succeed())
-				})
-
-				it.After(func() {
-					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+					pyProjectParser.ParseCall.Returns.String = "some-script"
 				})
 
 				it("returns an error", func() {

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -2,8 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,16 +81,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("Hello, World!"))
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
 		})
 	})
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -107,5 +107,6 @@ func TestIntegration(t *testing.T) {
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())
+	suite("RunTarget", testRunTargets, spec.Parallel())
 	suite.Run(t)
 }

--- a/integration/run_target_test.go
+++ b/integration/run_target_test.go
@@ -1,0 +1,131 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testRunTargets(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when BP_POETRY_RUN_TARGET is set", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+			name      string
+			source    string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "run_target_app"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		context("when BP_POETRY_RUN_TARGET is set to an executable command", func() {
+			it("builds and runs successfully", func() {
+				var err error
+				var logs fmt.Stringer
+
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						settings.Buildpacks.CPython.Online,
+						settings.Buildpacks.Pip.Online,
+						settings.Buildpacks.Poetry.Online,
+						settings.Buildpacks.PoetryInstall.Online,
+						settings.Buildpacks.PoetryRun.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					).
+					WithEnv(map[string]string{
+						"BP_POETRY_RUN_TARGET": "python -V",
+					}).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+					"  Assigning launch process",
+					"    web: poetry run python -V",
+				))
+
+				container, err = docker.Container.Run.
+					Execute(image.ID)
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(MatchRegexp(`Python 3\.\d+\.\d+`))
+			})
+		})
+
+		context("when BP_POETRY_RUN_TARGET is set to a script key", func() {
+			it("something", func() {
+				var err error
+				var logs fmt.Stringer
+
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						settings.Buildpacks.CPython.Online,
+						settings.Buildpacks.Pip.Online,
+						settings.Buildpacks.Poetry.Online,
+						settings.Buildpacks.PoetryInstall.Online,
+						settings.Buildpacks.PoetryRun.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					).
+					WithEnv(map[string]string{
+						"BP_POETRY_RUN_TARGET": "working-script-key",
+					}).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+					"  Assigning launch process",
+					"    web: poetry run working-script-key",
+				))
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					Execute(image.ID)
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")).OnPort(8080))
+			})
+		})
+	})
+}

--- a/integration/testdata/run_target_app/default_app/server.py
+++ b/integration/testdata/run_target_app/default_app/server.py
@@ -1,0 +1,15 @@
+import os
+
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def hello_world():
+    return 'Hello, World!'
+
+if __name__ == "__main__":
+    app.run()
+
+def run():
+    port = int(os.getenv("PORT"))
+    app.run(host='0.0.0.0', port=port)

--- a/integration/testdata/run_target_app/plan.toml
+++ b/integration/testdata/run_target_app/plan.toml
@@ -1,0 +1,11 @@
+[[requires]]
+  name = "poetry-venv"
+
+  [requires.metadata]
+    launch = true
+
+[[requires]]
+  name = "cpython"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/run_target_app/poetry.lock
+++ b/integration/testdata/run_target_app/poetry.lock
@@ -1,0 +1,150 @@
+[[package]]
+name = "click"
+version = "8.0.4"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "flask"
+version = "2.0.3"
+description = "A simple framework for building complex web applications."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.2"
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.0"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+
+[[package]]
+name = "itsdangerous"
+version = "2.1.1"
+description = "Safely pass data to untrusted environments and back."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "jinja2"
+version = "3.0.3"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "werkzeug"
+version = "2.0.3"
+description = "The comprehensive WSGI web application library."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+watchdog = ["watchdog"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "f2fd80c959248516064060be2c90a024e8acbeec3616817da0b9a5c3822a7d61"
+
+[metadata.files]
+click = [
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+flask = [
+    {file = "Flask-2.0.3-py3-none-any.whl", hash = "sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f"},
+    {file = "Flask-2.0.3.tar.gz", hash = "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"},
+]
+itsdangerous = [
+    {file = "itsdangerous-2.1.1-py3-none-any.whl", hash = "sha256:935642cd4b987cdbee7210080004033af76306757ff8b4c0a506a4b6e06f02cf"},
+    {file = "itsdangerous-2.1.1.tar.gz", hash = "sha256:7b7d3023cd35d9cb0c1fd91392f8c95c6fa02c59bf8ad64b8849be3401b95afb"},
+]
+jinja2 = [
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]
+werkzeug = [
+    {file = "Werkzeug-2.0.3-py3-none-any.whl", hash = "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8"},
+    {file = "Werkzeug-2.0.3.tar.gz", hash = "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"},
+]

--- a/integration/testdata/run_target_app/pyproject.toml
+++ b/integration/testdata/run_target_app/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "default_app"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.10"
+Flask = "^2.0.3"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+bad-script-key = "this_script:does_nothing"
+working-script-key = "default_app.server:run"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/run/main.go
+++ b/run/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	logger := scribe.NewEmitter(os.Stdout)
+	logger := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
 	pyProjectParser := poetryrun.NewPyProjectConfigParser()
 
 	packit.Run(


### PR DESCRIPTION
## Summary
Add `BP_POETRY_RUN_TARGET` to configure the poetry run command.

This changes detection criteria, since inspecting `pyproject.toml` is no longer required when `BP_POETRY_RUN_TARGET` is set. See updated `README` for details.

Resolves #10.

Integration test not added.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
