### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
   id = "paketo-buildpacks/poetry-run"
-  name = "Paketo Poetry Run Buildpack"
+  name = "Paketo Buildpack for Poetry Run"
 
 [metadata]
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]


### PR DESCRIPTION
Renames 'Paketo Poetry Run Buildpack' to 'Paketo Buildpack for Poetry Run'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
